### PR TITLE
Fixing a division by zero if num_defocus = 1

### DIFF
--- a/src/guanaco/detail/correct.py
+++ b/src/guanaco/detail/correct.py
@@ -464,7 +464,10 @@ def correct_file(
 
             # Compute step defocus if necessary
             if step_defocus is None:
-                step_defocus = (max_defocus - min_defocus) / (num_defocus - 1)
+                if num_defocus == 1:
+                    step_defocus = 0
+                else:
+                    step_defocus = (max_defocus - min_defocus) / (num_defocus - 1)
 
             # Set the corrected data metadata
             for j in range(output_shape[0]):


### PR DESCRIPTION
I got the following error when I used num_defocus=1 :
```
Traceback (most recent call last):
  File "/home/0000-0002-8015-3191/workspace-ceph/Installations/miniconda3/bin/parakeet.analyse.correct", line 8, in <module>
    sys.exit(correct())
  File "/home/0000-0002-8015-3191/workspace-ceph/Installations/miniconda3/lib/python3.9/site-packages/parakeet/command_line/analyse.py", line 179, in correct
    parakeet.analyse.correct(
  File "/home/0000-0002-8015-3191/workspace-ceph/Installations/miniconda3/lib/python3.9/site-packages/parakeet/analyse.py", line 111, in correct
    guanaco.correct_file(
  File "/home/0000-0002-8015-3191/workspace-ceph/Installations/miniconda3/lib/python3.9/site-packages/guanaco/detail/correct.py", line 467, in correct_file
    step_defocus = (max_defocus - min_defocus) / (num_defocus - 1)
ZeroDivisionError: division by zero
```
And so I fixed the corresponding code